### PR TITLE
feat(BUILD-11337): add ubuntu1604 to vars/main.yml

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,7 @@
 distro_dict:
   Debian: debian
   RedHat: rhel
+  Ubuntu16: ubuntu1604
 distro: "{{ distro_dict[ansible_os_family] }}"
 architecture_dict:
   x86_64: 64bit


### PR DESCRIPTION
### Add ubuntu1604 to vars/main.yml

In my patch with the current release version it tried to pull https://s3.amazonaws.com/boxes.10gen.com/build/toolchain-drivers/mongo-php-driver/php-toolchain-debian16.04-64bit-37dbfb7b800408897e2dbb6c85ae9e67ce6f7c49.tar.gz for ubuntu 16.04 distro 